### PR TITLE
Build settings upgraded for Android Studio 3.2.1

### DIFF
--- a/client/java/SafetyNetSample/Application/build.gradle
+++ b/client/java/SafetyNetSample/Application/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile "com.android.support:support-v4:$support_version"
-    compile "com.android.support:support-v13:$support_version"
-    compile "com.android.support:cardview-v7:$support_version"
-    compile "com.android.support:appcompat-v7:$support_version"
-    compile "com.google.android.gms:play-services-safetynet:$google_play_services_version"
+    implementation "com.android.support:support-v4:$support_version"
+    implementation "com.android.support:support-v13:$support_version"
+    implementation "com.android.support:cardview-v7:$support_version"
+    implementation "com.android.support:appcompat-v7:$support_version"
+    implementation "com.google.android.gms:play-services-safetynet:$google_play_services_version"
 }
 
 // The sample build uses multiple directories to
@@ -18,7 +18,7 @@ List<String> dirs = [
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "$build_tools_version"
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.example.android.safetynetsample"

--- a/client/java/SafetyNetSample/build.gradle
+++ b/client/java/SafetyNetSample/build.gradle
@@ -1,20 +1,20 @@
 buildscript {
     repositories {
-        maven { url 'https://maven.google.com' }
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 
-    ext.build_tools_version = '25.0.3'
-    ext.support_version = '25.3.1'
-    ext.google_play_services_version = '11.0.1'
+    ext.build_tools_version = '28.0.3'
+    ext.support_version = '26.1.0'
+    ext.google_play_services_version = '16.0.0'
 
     allprojects {
         repositories {
-            maven { url 'https://maven.google.com' }
+            google()
             jcenter()
         }
     }

--- a/client/java/SafetyNetSample/gradle/wrapper/gradle-wrapper.properties
+++ b/client/java/SafetyNetSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 09 16:53:43 AEST 2017
+#Wed Dec 12 09:55:42 JST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
I tried to build an android-play-safetynet client sample project with Android Studio 3.2.1, but it failed by the following errors.
It requires to upgrade the maven repositories and the dependencies.
I send the pull request to solve the problem.

```
Could not find com.android.tools.build:gradle:2.3.3.
Searched in the following locations:
    https://maven.google.com/com/android/tools/build/gradle/2.3.3/gradle-2.3.3.pom
    https://maven.google.com/com/android/tools/build/gradle/2.3.3/gradle-2.3.3.jar
    https://jcenter.bintray.com/com/android/tools/build/gradle/2.3.3/gradle-2.3.3.pom
    https://jcenter.bintray.com/com/android/tools/build/gradle/2.3.3/gradle-2.3.3.jar
Required by:
    project :
Add Google Maven repository and sync project
Open File
```
