### PR TITLE
Resolve Issue #19

### DIFF
--- a/server/java/src/main/java/AttestationStatement.java
+++ b/server/java/src/main/java/AttestationStatement.java
@@ -79,7 +79,7 @@ public class AttestationStatement extends JsonWebSignature.Payload {
     }
 
     public byte[] getApkDigestSha256() {
-        return Base64.decodeBase64(apkDigestSha256);
+        return apkDigestSha256 != null ? Base64.decodeBase64(apkDigestSha256) : new byte[0];
     }
 
     public byte[][] getApkCertificateDigestSha256() {


### PR DESCRIPTION
`getApkDigestSha256()` now null checks the backing field, and if is null, returns an empty byte array